### PR TITLE
feature[TW28966]: Prevent self modification in TaskMover

### DIFF
--- a/plugins/org.eclipse.osee.ats.ide/src/org/eclipse/osee/ats/ide/workflow/task/internal/TaskMover.java
+++ b/plugins/org.eclipse.osee.ats.ide/src/org/eclipse/osee/ats/ide/workflow/task/internal/TaskMover.java
@@ -41,6 +41,9 @@ public class TaskMover {
       for (IAtsTask task : tasks) {
          TaskArtifact taskArt = (TaskArtifact) task;
          taskArt.clearCaches();
+         if (newParent.equals(taskArt.getParentAWA())) {
+            continue;
+         }
          if (taskArt.getParentAWA() != null) {
             changes.unrelateAll(taskArt, AtsRelationTypes.TeamWfToTask_TeamWorkflow);
          }


### PR DESCRIPTION
Fixes minor bug where a task moved a little and dropped on the same workflow caused a add/drop transaction.