### PR TITLE
feature[TW29610]: Add sort capability to generic report

### DIFF
--- a/docs/OSEE/GenericReport.md
+++ b/docs/OSEE/GenericReport.md
@@ -154,6 +154,22 @@ If any attribute column of the given type produces a value matching the regex, t
 .filter(CoreAttributeTypes.Name, ".*DELETED.*")
 ```
 
+## Sorting
+
+Sorting allows the artifacts at a given level to be ordered by the value of a single attribute type before they are processed into report rows.
+
+### `sort(AttributeTypeToken type)`
+
+Sorts the artifacts at the current level by the specified attribute type using case-insensitive string ordering. Artifacts with no value for the sort attribute are placed at the end. The sort applies to both the top-level query results (depth 0) and child-level artifacts retrieved via relations.
+
+```java
+report.level("Requirements",
+   report.query().andIsOfType(CoreArtifactTypes.SubsystemRequirementMsWord))
+   .sort(CoreAttributeTypes.Name)
+   .column("Artifact Id")
+   .column("Requirement Name", CoreAttributeTypes.Name);
+```
+
 ## Running the Report
 
 ### Synchronous Endpoint

--- a/plugins/org.eclipse.osee.ats.ide.integration.tests/src/org/eclipse/osee/ats/ide/integration/tests/orcs/rest/ReportEndpointTest.java
+++ b/plugins/org.eclipse.osee.ats.ide.integration.tests/src/org/eclipse/osee/ats/ide/integration/tests/orcs/rest/ReportEndpointTest.java
@@ -706,4 +706,131 @@ public class ReportEndpointTest {
          response.close();
       }
    }
+
+   /**
+    * Tests the applyHierarchyNumbers endpoint using query parameters for attributeType and padding.
+    * Verifies that a valid allowed attribute type (ParagraphNumber) succeeds.
+    */
+   @Test
+   public void testApplyHierarchyNumbersWithQueryParams() {
+      String branchId = DemoBranches.SAW_PL_Working_Branch.getIdString();
+      String artifactId = subsystemReqArt.getIdString();
+      long paragraphNumberTypeId = CoreAttributeTypes.ParagraphNumber.getId();
+
+      String url = String.format("orcs/report/%s/hierarchyNumber/%s?attributeType=%d&padding=3", branchId, artifactId,
+         paragraphNumberTypeId);
+
+      Response response = jaxRsApi.newTarget(url).request(MediaType.APPLICATION_JSON).put(null);
+      try {
+         assertEquals("Hierarchy numbering with query params should return successful response", Family.SUCCESSFUL,
+            response.getStatusInfo().getFamily());
+
+         String responseBody = readResponseBody(response);
+         assertTrue("Response should contain success log",
+            responseBody.contains("Hierarchy numbering committed successfully"));
+      } finally {
+         response.close();
+      }
+   }
+
+   /**
+    * Tests that the applyHierarchyNumbers endpoint uses the default padding value (2) when the padding query parameter
+    * is omitted.
+    */
+   @Test
+   public void testApplyHierarchyNumbersDefaultPadding() {
+      String branchId = DemoBranches.SAW_PL_Working_Branch.getIdString();
+      String artifactId = subsystemReqArt.getIdString();
+      long paragraphNumberTypeId = CoreAttributeTypes.ParagraphNumber.getId();
+
+      String url =
+         String.format("orcs/report/%s/hierarchyNumber/%s?attributeType=%d", branchId, artifactId, paragraphNumberTypeId);
+
+      Response response = jaxRsApi.newTarget(url).request(MediaType.APPLICATION_JSON).put(null);
+      try {
+         assertEquals("Hierarchy numbering with default padding should return successful response", Family.SUCCESSFUL,
+            response.getStatusInfo().getFamily());
+
+         String responseBody = readResponseBody(response);
+         assertTrue("Response should indicate padding 2 (default)",
+            responseBody.contains("padding 2"));
+      } finally {
+         response.close();
+      }
+   }
+
+   /**
+    * Tests that the applyHierarchyNumbers endpoint rejects an attribute type that is not in the allowlist.
+    */
+   @Test
+   public void testApplyHierarchyNumbersDisallowedAttributeType() {
+      String branchId = DemoBranches.SAW_PL_Working_Branch.getIdString();
+      String artifactId = subsystemReqArt.getIdString();
+      // Use Name attribute type which is not in the allowed list
+      long nameTypeId = CoreAttributeTypes.Name.getId();
+
+      String url = String.format("orcs/report/%s/hierarchyNumber/%s?attributeType=%d&padding=2", branchId, artifactId,
+         nameTypeId);
+
+      Response response = jaxRsApi.newTarget(url).request(MediaType.APPLICATION_JSON).put(null);
+      try {
+         assertEquals("Disallowed attribute type should still return successful HTTP status", Family.SUCCESSFUL,
+            response.getStatusInfo().getFamily());
+
+         String responseBody = readResponseBody(response);
+         assertTrue("Response should contain error about disallowed attribute type",
+            responseBody.contains("is not allowed for hierarchy numbering"));
+      } finally {
+         response.close();
+      }
+   }
+
+   /**
+    * Tests that the applyHierarchyNumbers endpoint rejects invalid padding values via query params.
+    */
+   @Test
+   public void testApplyHierarchyNumbersInvalidPadding() {
+      String branchId = DemoBranches.SAW_PL_Working_Branch.getIdString();
+      String artifactId = subsystemReqArt.getIdString();
+      long paragraphNumberTypeId = CoreAttributeTypes.ParagraphNumber.getId();
+
+      String url = String.format("orcs/report/%s/hierarchyNumber/%s?attributeType=%d&padding=10", branchId, artifactId,
+         paragraphNumberTypeId);
+
+      Response response = jaxRsApi.newTarget(url).request(MediaType.APPLICATION_JSON).put(null);
+      try {
+         assertEquals("Invalid padding should still return successful HTTP status", Family.SUCCESSFUL,
+            response.getStatusInfo().getFamily());
+
+         String responseBody = readResponseBody(response);
+         assertTrue("Response should contain error about padding range",
+            responseBody.contains("Padding must be between 1 and"));
+      } finally {
+         response.close();
+      }
+   }
+
+   /**
+    * Tests that the applyHierarchyNumbers endpoint returns a clear error when the attributeType query parameter is
+    * omitted.
+    */
+   @Test
+   public void testApplyHierarchyNumbersMissingAttributeType() {
+      String branchId = DemoBranches.SAW_PL_Working_Branch.getIdString();
+      String artifactId = subsystemReqArt.getIdString();
+
+      String url = String.format("orcs/report/%s/hierarchyNumber/%s?padding=2", branchId, artifactId);
+
+      Response response = jaxRsApi.newTarget(url).request(MediaType.APPLICATION_JSON).put(null);
+      try {
+         assertEquals("Missing attributeType should still return successful HTTP status", Family.SUCCESSFUL,
+            response.getStatusInfo().getFamily());
+
+         String responseBody = readResponseBody(response);
+         assertTrue("Response should contain error about missing attributeType",
+            responseBody.contains("attributeType query parameter is required"));
+      } finally {
+         response.close();
+      }
+   }
 }

--- a/plugins/org.eclipse.osee.orcs.rest.model/src/org/eclipse/osee/orcs/rest/model/GenericReport.java
+++ b/plugins/org.eclipse.osee.orcs.rest.model/src/org/eclipse/osee/orcs/rest/model/GenericReport.java
@@ -41,6 +41,8 @@ public interface GenericReport {
 
    public GenericReport filter(AttributeTypeToken type, String regex);
 
+   public GenericReport sort(AttributeTypeToken type);
+
    public QueryBuilder query();
 
    public OrcsApi getOrcsApi();

--- a/plugins/org.eclipse.osee.orcs.rest.model/src/org/eclipse/osee/orcs/rest/model/ReportEndpoint.java
+++ b/plugins/org.eclipse.osee.orcs.rest.model/src/org/eclipse/osee/orcs/rest/model/ReportEndpoint.java
@@ -15,15 +15,18 @@ package org.eclipse.osee.orcs.rest.model;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.eclipse.osee.framework.core.data.ArtifactId;
 import org.eclipse.osee.framework.core.data.BranchId;
 import org.eclipse.osee.framework.jdk.core.annotation.Swagger;
+import org.eclipse.osee.framework.jdk.core.result.XResultData;
 
 /**
  * @author David W. Miller
@@ -46,5 +49,12 @@ public interface ReportEndpoint {
       @DefaultValue("-1") @PathParam("view") ArtifactId view,
       @DefaultValue("-1") @PathParam("template") ArtifactId templateArt,
       @PathParam("email") String emailRecipient);
+
+   @PUT
+   @Path("{branch}/hierarchyNumber/{artifact}")
+   @Produces({MediaType.APPLICATION_JSON})
+   XResultData applyHierarchyNumbers(@PathParam("branch") BranchId branch,
+      @PathParam("artifact") ArtifactId startArtifact, @QueryParam("attributeType") long attributeTypeId,
+      @DefaultValue("2") @QueryParam("padding") int padding);
 
 }

--- a/plugins/org.eclipse.osee.orcs.rest.test/src/org/eclipse/osee/orcs/rest/internal/GenericReportBuilderTest.java
+++ b/plugins/org.eclipse.osee.orcs.rest.test/src/org/eclipse/osee/orcs/rest/internal/GenericReportBuilderTest.java
@@ -453,4 +453,106 @@ public class GenericReportBuilderTest {
             ex.getMessage().contains("followFork cannot be called before creating a level"));
       }
    }
+
+   @Test(expected = OseeArgumentException.class)
+   public void testSortBeforeLevelThrowsException() {
+      report.sort(nameAttrType);
+   }
+
+   @Test
+   public void testSortSetsAttributeOnCurrentLevel() {
+      when(tokenService.getArtifactType("Folder")).thenReturn(artifactType);
+      when(queryBuilder.andIsOfType(artifactType)).thenReturn(queryBuilder);
+
+      report.level("Folders", "Folder").sort(nameAttrType);
+
+      assertEquals(nameAttrType, report.getLevels().get(0).getSortByAttribute());
+   }
+
+   @Test
+   public void testSortOrdersResultsAscendingCaseInsensitive() {
+      when(tokenService.getArtifactType("Folder")).thenReturn(artifactType);
+      when(queryBuilder.andIsOfType(artifactType)).thenReturn(queryBuilder);
+
+      ArtifactReadable artifact3 = org.mockito.Mockito.mock(ArtifactReadable.class);
+
+      when(queryBuilder.asArtifacts()).thenReturn(Arrays.asList(artifact1, artifact2, artifact3));
+
+      when(artifact1.getIdString()).thenReturn("100");
+      when(artifact1.getAttributeValuesAsString(nameAttrType)).thenReturn("Charlie");
+      when(artifact2.getIdString()).thenReturn("200");
+      when(artifact2.getAttributeValuesAsString(nameAttrType)).thenReturn("alpha");
+      when(artifact3.getIdString()).thenReturn("300");
+      when(artifact3.getAttributeValuesAsString(nameAttrType)).thenReturn("Bravo");
+
+      report.level("Folders", "Folder").column("Id").column("Name", nameAttrType).sort(nameAttrType);
+
+      List<Object[]> rows = new ArrayList<>();
+      report.getDataRowsFromQuery(rows);
+
+      // rows[0] = top, rows[1] = header, rows[2..4] = data sorted by name (case-insensitive)
+      assertEquals(5, rows.size());
+      assertEquals("alpha", ((String[]) rows.get(2))[1]);
+      assertEquals("Bravo", ((String[]) rows.get(3))[1]);
+      assertEquals("Charlie", ((String[]) rows.get(4))[1]);
+   }
+
+   @Test
+   public void testSortPlacesNullValuesAtEnd() {
+      when(tokenService.getArtifactType("Folder")).thenReturn(artifactType);
+      when(queryBuilder.andIsOfType(artifactType)).thenReturn(queryBuilder);
+
+      ArtifactReadable artifact3 = org.mockito.Mockito.mock(ArtifactReadable.class);
+
+      when(queryBuilder.asArtifacts()).thenReturn(Arrays.asList(artifact1, artifact2, artifact3));
+
+      when(artifact1.getIdString()).thenReturn("100");
+      when(artifact1.getAttributeValuesAsString(nameAttrType)).thenReturn(null);
+      when(artifact2.getIdString()).thenReturn("200");
+      when(artifact2.getAttributeValuesAsString(nameAttrType)).thenReturn("Zebra");
+      when(artifact3.getIdString()).thenReturn("300");
+      when(artifact3.getAttributeValuesAsString(nameAttrType)).thenReturn("Apple");
+
+      report.level("Folders", "Folder").column("Id").column("Name", nameAttrType).sort(nameAttrType);
+
+      List<Object[]> rows = new ArrayList<>();
+      report.getDataRowsFromQuery(rows);
+
+      // Sorted: Apple, Zebra, null-at-end
+      assertEquals(5, rows.size());
+      assertEquals("Apple", ((String[]) rows.get(2))[1]);
+      assertEquals("Zebra", ((String[]) rows.get(3))[1]);
+      assertEquals(null, ((String[]) rows.get(4))[1]);
+   }
+
+   @Test
+   public void testSortWithSingleElementDoesNotChangeOrder() {
+      when(tokenService.getArtifactType("Folder")).thenReturn(artifactType);
+      when(queryBuilder.andIsOfType(artifactType)).thenReturn(queryBuilder);
+      when(queryBuilder.asArtifacts()).thenReturn(Arrays.asList(artifact1));
+
+      when(artifact1.getIdString()).thenReturn("100");
+      when(artifact1.getAttributeValuesAsString(nameAttrType)).thenReturn("Only One");
+
+      report.level("Folders", "Folder").column("Id").column("Name", nameAttrType).sort(nameAttrType);
+
+      List<Object[]> rows = new ArrayList<>();
+      report.getDataRowsFromQuery(rows);
+
+      assertEquals(3, rows.size());
+      assertEquals("Only One", ((String[]) rows.get(2))[1]);
+   }
+
+   @Test
+   public void testSortAppliedPerLevel() {
+      when(tokenService.getArtifactType("Folder")).thenReturn(artifactType);
+      when(tokenService.getArtifactType("File")).thenReturn(artifactType);
+      when(queryBuilder.andIsOfType(artifactType)).thenReturn(queryBuilder);
+
+      report.level("Folders", "Folder").column("Id").sort(nameAttrType);
+      report.level("Files", "File").column("Id").sort(descAttrType);
+
+      assertEquals(nameAttrType, report.getLevels().get(0).getSortByAttribute());
+      assertEquals(descAttrType, report.getLevels().get(1).getSortByAttribute());
+   }
 }

--- a/plugins/org.eclipse.osee.orcs.rest/src/org/eclipse/osee/orcs/rest/internal/ReportEndpointImpl.java
+++ b/plugins/org.eclipse.osee.orcs.rest/src/org/eclipse/osee/orcs/rest/internal/ReportEndpointImpl.java
@@ -16,14 +16,23 @@ package org.eclipse.osee.orcs.rest.internal;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.StreamingOutput;
 import org.eclipse.osee.framework.core.data.ArtifactId;
+import org.eclipse.osee.framework.core.data.ArtifactReadable;
+import org.eclipse.osee.framework.core.data.AttributeTypeToken;
 import org.eclipse.osee.framework.core.data.BranchId;
 import org.eclipse.osee.framework.core.data.OseeClient;
+import org.eclipse.osee.framework.core.enums.CoreAttributeTypes;
+import org.eclipse.osee.framework.core.enums.CoreRelationTypes;
+import org.eclipse.osee.framework.core.enums.CoreUserGroups;
+import org.eclipse.osee.framework.core.enums.DeletionFlag;
 import org.eclipse.osee.framework.core.util.IOseeEmail;
 import org.eclipse.osee.framework.core.util.OseeEmail.BodyType;
+import org.eclipse.osee.framework.jdk.core.result.XResultData;
 import org.eclipse.osee.framework.jdk.core.type.OseeArgumentException;
 import org.eclipse.osee.framework.jdk.core.type.OseeCoreException;
 import org.eclipse.osee.framework.jdk.core.util.EmailUtil;
@@ -31,6 +40,7 @@ import org.eclipse.osee.framework.jdk.core.util.Lib;
 import org.eclipse.osee.orcs.OrcsApi;
 import org.eclipse.osee.orcs.rest.internal.writers.PublishTemplateReport;
 import org.eclipse.osee.orcs.rest.model.ReportEndpoint;
+import org.eclipse.osee.orcs.transaction.TransactionBuilder;
 
 /**
  * @author David W. Miller
@@ -103,6 +113,105 @@ public final class ReportEndpointImpl implements ReportEndpoint {
       }
 
       return Response.ok(jsonResponse).build();
+   }
+
+   private static final int MAX_HIERARCHY_DEPTH = 100;
+   private static final int MAX_PADDING = 5;
+   private static final Set<Long> ALLOWED_NUMBERING_ATTRIBUTE_TYPES = Set.of( //
+      CoreAttributeTypes.Annotation.getId(), //
+      CoreAttributeTypes.Description.getId(), //
+      CoreAttributeTypes.DoorsHierarchy.getId(), //
+      CoreAttributeTypes.ParagraphNumber.getId());
+
+   @Override
+   public XResultData applyHierarchyNumbers(BranchId branch, ArtifactId startArtifact, long attributeTypeId,
+      int padding) {
+         
+      XResultData results = new XResultData();
+      orcsApi.userService().requireRole(CoreUserGroups.OseeAccessAdmin);
+      
+      if (padding < 1 || padding > MAX_PADDING) {
+         results.errorf("Padding must be between 1 and %d, got %d", MAX_PADDING, padding);
+         return results;
+      }
+
+      if (attributeTypeId == 0L) {
+         results.errorf("attributeType query parameter is required");
+         return results;
+      }
+
+      if (!ALLOWED_NUMBERING_ATTRIBUTE_TYPES.contains(attributeTypeId)) {
+         results.errorf("Attribute type %d is not allowed for hierarchy numbering. Allowed types: Annotation, Description, DoorsHierarchy, ParagraphNumber",
+            attributeTypeId);
+         return results;
+      }
+
+      AttributeTypeToken attributeType = orcsApi.tokenService().getAttributeType(attributeTypeId);
+      ArtifactReadable rootArt = orcsApi.getQueryFactory().fromBranch(branch).andId(startArtifact).getArtifact();
+
+      if (rootArt == null) {
+         results.errorf("Artifact %s not found on branch %s", startArtifact, branch);
+         return results;
+      }
+
+      TransactionBuilder tx = orcsApi.getTransactionFactory().createTransaction(branch, "Apply hierarchy numbers");
+
+      int maxNumber = intPow(10, padding) - 1;
+      results.logf("Applying hierarchy numbers starting at artifact %s with padding %d (max per level: %d)",
+         rootArt.getIdString(), padding, maxNumber);
+
+      try {
+         int count = applyHierarchyNumbersRecursive(rootArt, "", attributeType, padding, maxNumber, tx, results, 0);
+         tx.commit();
+         results.logf("Hierarchy numbering committed successfully. %d artifacts numbered.", count);
+      } catch (Exception ex) {
+         results.errorf("Error during hierarchy numbering, transaction discarded: %s", ex.getMessage());
+      }
+      return results;
+   }
+
+   private static int intPow(int base, int exponent) {
+      int result = 1;
+      for (int i = 0; i < exponent; i++) {
+         result *= base;
+      }
+      return result;
+   }
+
+   private int applyHierarchyNumbersRecursive(ArtifactReadable artifact, String prefix,
+      AttributeTypeToken attributeType, int padding, int maxNumber, TransactionBuilder tx, XResultData results,
+      int depth) {
+      if (depth >= MAX_HIERARCHY_DEPTH) {
+         results.warningf("Maximum hierarchy depth (%d) reached at artifact %s — skipping deeper levels.",
+            MAX_HIERARCHY_DEPTH, artifact.getIdString());
+         return 0;
+      }
+
+      List<ArtifactReadable> children =
+         artifact.getRelated(CoreRelationTypes.DefaultHierarchical_Child, DeletionFlag.EXCLUDE_DELETED);
+
+      int count = 0;
+      int index = 0;
+      for (ArtifactReadable child : children) {
+         index++;
+         int number = Math.min(index, maxNumber);
+         String segment = String.format("%0" + padding + "d", number);
+         String hierarchyNumber = prefix.isEmpty() ? segment : prefix + "." + segment;
+
+         try {
+            tx.setSoleAttributeFromString(child, attributeType, hierarchyNumber);
+            results.logf("Set %s = %s on artifact %s", attributeType.getName(), hierarchyNumber,
+               child.getIdString());
+            count++;
+         } catch (OseeArgumentException ex) {
+            results.warningf("Skipping artifact %s: attribute type %s not valid for artifact type - %s",
+               child.getIdString(), attributeType.getName(), ex.getMessage());
+         }
+
+         count += applyHierarchyNumbersRecursive(child, hierarchyNumber, attributeType, padding, maxNumber, tx,
+            results, depth + 1);
+      }
+      return count;
    }
 
 }

--- a/plugins/org.eclipse.osee.orcs.rest/src/org/eclipse/osee/orcs/rest/internal/writers/GenericReportBuilder.java
+++ b/plugins/org.eclipse.osee.orcs.rest/src/org/eclipse/osee/orcs/rest/internal/writers/GenericReportBuilder.java
@@ -12,7 +12,9 @@
  **********************************************************************/
 package org.eclipse.osee.orcs.rest.internal.writers;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import org.eclipse.osee.framework.core.data.ArtifactId;
@@ -180,6 +182,15 @@ public class GenericReportBuilder implements GenericReport {
       return this;
    }
 
+   @Override
+   public GenericReport sort(AttributeTypeToken type) {
+      if (currentLevel == null) {
+         throw new OseeArgumentException("sort cannot be called before creating a level");
+      }
+      currentLevel.setSortByAttribute(type);
+      return this;
+   }
+
    /**
     * Returns the current query builder. Calling this finalizes the current relation level (if any) so that follow/fork
     * calls are emitted before the caller chains additional operations. This is critical for template code like
@@ -241,6 +252,9 @@ public class GenericReportBuilder implements GenericReport {
       rows.add(getTopRow());
       rows.add(getHeaderRow());
       String[] row = new String[getColumnCount()];
+
+      ReportLevel firstLevel = this.getLevels().get(0);
+      arts = sortArtsForLevel(arts, firstLevel);
 
       for (ArtifactReadable art : arts) {
          fillReportDataFromQuery(art, rows, row, 0, 0);
@@ -340,6 +354,21 @@ public class GenericReportBuilder implements GenericReport {
          }
          arts.addAll(art.getRelated(level.getRelation(), DeletionFlag.EXCLUDE_DELETED));
       }
-      return arts;
+      return sortArtsForLevel(arts, level);
+   }
+
+   /**
+    * Sorts the given artifact list by the level's sortByAttribute, if one is configured. Uses natural string ordering
+    * of the attribute value. Artifacts with no value for the sort attribute are placed at the end.
+    */
+   private List<ArtifactReadable> sortArtsForLevel(List<ArtifactReadable> arts, ReportLevel level) {
+      AttributeTypeToken sortAttr = level.getSortByAttribute();
+      if (sortAttr == null || arts.size() <= 1) {
+         return arts;
+      }
+      List<ArtifactReadable> sorted = new ArrayList<>(arts);
+      sorted.sort(Comparator.comparing(a -> a.getAttributeValuesAsString(sortAttr),
+         Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+      return sorted;
    }
 }

--- a/plugins/org.eclipse.osee.orcs/src/org/eclipse/osee/orcs/search/ReportLevel.java
+++ b/plugins/org.eclipse.osee.orcs/src/org/eclipse/osee/orcs/search/ReportLevel.java
@@ -35,6 +35,7 @@ public class ReportLevel {
    private final List<RelationTypeSide> forkRelations = new LinkedList<>();
    /** Tracks all relation names used in this level (main + forks) to prevent duplicates */
    private final Set<String> forkRelationNames = new HashSet<>();
+   private AttributeTypeToken sortByAttribute;
 
    public ReportLevel(String levelName) {
       this.levelName = levelName;
@@ -127,6 +128,14 @@ public class ReportLevel {
       }
       all.addAll(forkRelations);
       return all;
+   }
+
+   public void setSortByAttribute(AttributeTypeToken sortByAttribute) {
+      this.sortByAttribute = sortByAttribute;
+   }
+
+   public AttributeTypeToken getSortByAttribute() {
+      return sortByAttribute;
    }
 
    private List<ReportColumn> getColumnsOfType(AttributeTypeToken type) {


### PR DESCRIPTION
This adds two new capabilities - a sort method for the generic report, and a REST endpoint to put some sortable numbers matching the hierarchy depth into a given attribute.